### PR TITLE
[WIP] attempt using current graph target option to display currently open graph path in extension

### DIFF
--- a/src/DynamoConnector.ts
+++ b/src/DynamoConnector.ts
@@ -84,6 +84,13 @@ export const useDynamoConnector = () => {
             }
             throw e;
           });
+        case "getCurrentGraphInfo":
+          return Dynamo.info(getDynamoUrl(), {}).catch((e) => {
+            if (!(e.status === 500)) {
+              setState(DynamoState.LOST_CONNECTION);
+            }
+            throw e;
+          });
         case "runGraph":
           // eslint-disable-next-line no-case-declarations
           const { code, inputs } = payload;

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -103,6 +103,17 @@ function ScriptList({ setScript, dynamoHandler }: any) {
   const [error, setError] = useState<string | null>(null);
   const [folder, setFolder] = useState<undefined | string>();
   const [isLoading, setIsLoading] = useState(false);
+  
+  const getCurrentGraphPath = useCallback(
+    () => {
+      (async function () {
+        const resp = await dynamoHandler("getCurrentGraphInfo");
+        console.log(resp.id)
+        setFolder(resp.id);
+      })();
+    },
+    [dynamoHandler],
+  );
 
   const reload = useCallback(
     (folder: string | undefined) => {
@@ -168,9 +179,13 @@ function ScriptList({ setScript, dynamoHandler }: any) {
           showlabel="true"
           name="height"
           placeholder="Enter folder name"
-          onBlur={(e: any) => {
-            const folder = e?.target?.value;
+          onBlur={ (e: any) => {
+            getCurrentGraphPath();
+            
+            console.log({folder})
             setFolder(folder);
+            //const folder = e?.target?.value;
+            // setFolder(folder);
           }}
         />
 

--- a/src/pages/LocalScript.tsx
+++ b/src/pages/LocalScript.tsx
@@ -213,6 +213,7 @@ export function LocalScript({ script, setScript, dynamoHandler }: any) {
         return;
       }
       const code = scriptInfo.data;
+      console.log({code});
       setOutput({ type: "running" });
       const urn = await Forma.proposal.getRootUrn();
       const inputs = await Promise.all(

--- a/src/service/dynamo.ts
+++ b/src/service/dynamo.ts
@@ -16,8 +16,7 @@ export function createTarget(code: any) {
     };
   }
   return {
-    type: "JsonGraphTarget",
-    contents: JSON.stringify(code),
+    type: "CurrentGraphTarget",
   };
 }
 


### PR DESCRIPTION
This work is incomplete. 

The goal here is to display and load the currently open graph in Dynamo in the extension. 
Currently, the open graph path can be displayed in the UI but only on clicking in the text box.

TODO:
- Graph path should display in the text box even without first clicking on it
- Add steps to load the graph in the extension so inputs/outputs show in the UI and so that it can be run
- Continue supporting the use-case of copy-pasting a folder path and listing dyn files in it