### PR TITLE
Handle changes in locally running dynamo

### DIFF
--- a/src/pages/LocalScript.tsx
+++ b/src/pages/LocalScript.tsx
@@ -605,11 +605,8 @@ export function LocalScript({
             alignItems: "center",
           }}
         >
-          <h3>{script.name}</h3>
-          {/*
-          // This will reflect the name in local when the bug described in hook above is active
+          {/** Before the scriptInfo === loaded, use the script.name */}
           <h3>{(scriptInfo.type === "loaded" && scriptInfo.data.name) || script.name}</h3>
-          */}
         </div>
         <div
           style={{


### PR DESCRIPTION
Handle when files change in local dynamo, and reflect the changes in Forma. Fixes the state transitions i could find, except for the one below.

Still an improvement over the current state of the extension 